### PR TITLE
Support absolute URLs for images

### DIFF
--- a/templates/edit_vehicle.html
+++ b/templates/edit_vehicle.html
@@ -81,7 +81,11 @@
                     <label for="photo" class="block text-gray-700 font-medium mb-1">Фото автомобіля:</label>
                     <input type="file" id="photo" name="photo" accept="image/*" class="w-full p-3 border rounded-lg">
                     {% if vehicle.photo %}
-                        <p class="text-gray-600 text-sm mt-2">Поточне фото: <a href="{{ url_for('static', filename=vehicle.photo) }}" target="_blank">Переглянути</a></p>
+                        {% if vehicle.photo.startswith('http') %}
+                            <p class="text-gray-600 text-sm mt-2">Поточне фото: <a href="{{ vehicle.photo }}" target="_blank">Переглянути</a></p>
+                        {% else %}
+                            <p class="text-gray-600 text-sm mt-2">Поточне фото: <a href="{{ url_for('static', filename=vehicle.photo) }}" target="_blank">Переглянути</a></p>
+                        {% endif %}
                     {% endif %}
                 </div>
                 <button type="submit" class="w-full bg-blue-500 text-white p-3 rounded-lg hover:bg-blue-600 transition">Зберегти зміни</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -252,7 +252,11 @@
                             <tr>
                                 <td class="py-2 px-4 border-b">
                                     {% if vehicle.photo %}
-                                        <img src="{{ url_for('static', filename=vehicle.photo) }}" alt="Фото автомобіля" class="w-12 h-12 object-cover rounded-lg">
+                                        {% if vehicle.photo.startswith('http') %}
+                                            <img src="{{ vehicle.photo }}" alt="Фото автомобіля" class="w-12 h-12 object-cover rounded-lg">
+                                        {% else %}
+                                            <img src="{{ url_for('static', filename=vehicle.photo) }}" alt="Фото автомобіля" class="w-12 h-12 object-cover rounded-lg">
+                                        {% endif %}
                                     {% else %}
                                         <div class="w-12 h-12 bg-gray-200 flex items-center justify-center rounded-lg">
                                             <span class="text-gray-500 text-xs">Немає</span>

--- a/templates/vehicle.html
+++ b/templates/vehicle.html
@@ -134,7 +134,11 @@
                                             <td class="py-2 px-4 border-b">{{ expense.note or '' }}</td>
                                             <td class="py-2 px-4 border-b">
                                                 {% if expense.receipt_photo %}
-                                                    <a href="{{ url_for('static', filename=expense.receipt_photo) }}" target="_blank" class="text-blue-500 hover:underline">Переглянути</a>
+                                                    {% if expense.receipt_photo.startswith('http') %}
+                                                        <a href="{{ expense.receipt_photo }}" target="_blank" class="text-blue-500 hover:underline">Переглянути</a>
+                                                    {% else %}
+                                                        <a href="{{ url_for('static', filename=expense.receipt_photo) }}" target="_blank" class="text-blue-500 hover:underline">Переглянути</a>
+                                                    {% endif %}
                                                 {% else %}
                                                     Немає
                                                 {% endif %}


### PR DESCRIPTION
## Summary
- allow expense receipt links to use absolute URLs
- show vehicle thumbnails from Cloudinary links or static folder
- handle external URLs for current vehicle photo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ec51b17c833198ff8a11df879666