### PR TITLE
Add photo_url filter for template URLs

### DIFF
--- a/Avtopark.py
+++ b/Avtopark.py
@@ -200,6 +200,16 @@ def is_url_accessible(url):
         logging.error(f"Помилка перевірки доступності URL {url}: {str(e)}")
         return False
 
+
+@app.template_filter('photo_url')
+def photo_url(photo_path):
+    """Return a usable URL for a photo path."""
+    if not photo_path:
+        return photo_path
+    if photo_path.startswith('http'):
+        return photo_path
+    return url_for('static', filename=photo_path)
+
 def login_required(f):
     def decorated_function(*args, **kwargs):
         if 'user_id' not in session:

--- a/templates/edit_vehicle.html
+++ b/templates/edit_vehicle.html
@@ -81,11 +81,7 @@
                     <label for="photo" class="block text-gray-700 font-medium mb-1">Фото автомобіля:</label>
                     <input type="file" id="photo" name="photo" accept="image/*" class="w-full p-3 border rounded-lg">
                     {% if vehicle.photo %}
-                        {% if vehicle.photo.startswith('http') %}
-                            <p class="text-gray-600 text-sm mt-2">Поточне фото: <a href="{{ vehicle.photo }}" target="_blank">Переглянути</a></p>
-                        {% else %}
-                            <p class="text-gray-600 text-sm mt-2">Поточне фото: <a href="{{ url_for('static', filename=vehicle.photo) }}" target="_blank">Переглянути</a></p>
-                        {% endif %}
+                        <p class="text-gray-600 text-sm mt-2">Поточне фото: <a href="{{ vehicle.photo|photo_url }}" target="_blank">Переглянути</a></p>
                     {% endif %}
                 </div>
                 <button type="submit" class="w-full bg-blue-500 text-white p-3 rounded-lg hover:bg-blue-600 transition">Зберегти зміни</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -252,11 +252,7 @@
                             <tr>
                                 <td class="py-2 px-4 border-b">
                                     {% if vehicle.photo %}
-                                        {% if vehicle.photo.startswith('http') %}
-                                            <img src="{{ vehicle.photo }}" alt="Фото автомобіля" class="w-12 h-12 object-cover rounded-lg">
-                                        {% else %}
-                                            <img src="{{ url_for('static', filename=vehicle.photo) }}" alt="Фото автомобіля" class="w-12 h-12 object-cover rounded-lg">
-                                        {% endif %}
+                                        <img src="{{ vehicle.photo|photo_url }}" alt="Фото автомобіля" class="w-12 h-12 object-cover rounded-lg">
                                     {% else %}
                                         <div class="w-12 h-12 bg-gray-200 flex items-center justify-center rounded-lg">
                                             <span class="text-gray-500 text-xs">Немає</span>

--- a/templates/vehicle.html
+++ b/templates/vehicle.html
@@ -81,11 +81,7 @@
             <div class="flex flex-col md:flex-row">
                 <div class="md:w-1/3 mb-4 md:mb-0">
                     {% if vehicle.photo %}
-                        {% if vehicle.photo.startswith('http') %}
-                            <img src="{{ vehicle.photo }}" alt="Фото автомобіля" class="w-full h-48 object-cover rounded-lg">
-                        {% else %}
-                            <img src="{{ url_for('static', filename=vehicle.photo) }}" alt="Фото автомобіля" class="w-full h-48 object-cover rounded-lg">
-                        {% endif %}
+                        <img src="{{ vehicle.photo|photo_url }}" alt="Фото автомобіля" class="w-full h-48 object-cover rounded-lg">
                     {% else %}
                         <div class="w-full h-48 bg-gray-200 flex items-center justify-center rounded-lg">
                             <span class="text-gray-500">Фото відсутнє</span>
@@ -138,11 +134,7 @@
                                             <td class="py-2 px-4 border-b">{{ expense.note or '' }}</td>
                                             <td class="py-2 px-4 border-b">
                                                 {% if expense.receipt_photo %}
-                                                    {% if expense.receipt_photo.startswith('http') %}
-                                                        <a href="{{ expense.receipt_photo }}" target="_blank" class="text-blue-500 hover:underline">Переглянути</a>
-                                                    {% else %}
-                                                        <a href="{{ url_for('static', filename=expense.receipt_photo) }}" target="_blank" class="text-blue-500 hover:underline">Переглянути</a>
-                                                    {% endif %}
+                                                    <a href="{{ expense.receipt_photo|photo_url }}" target="_blank" class="text-blue-500 hover:underline">Переглянути</a>
                                                 {% else %}
                                                     Немає
                                                 {% endif %}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import pytest
 
 
 def load_utils():
-    """Load allowed_file and predict_expenses from Avtopark.py without full deps."""
+    """Load helper functions from Avtopark.py without full deps."""
     root = os.path.dirname(os.path.dirname(__file__))
     path = os.path.join(root, 'Avtopark.py')
     with open(path, encoding='utf-8') as f:
@@ -16,7 +16,7 @@ def load_utils():
     lines = source.splitlines()
     funcs = {}
     for node in tree.body:
-        if isinstance(node, ast.FunctionDef) and node.name in {'allowed_file', 'predict_expenses'}:
+        if isinstance(node, ast.FunctionDef) and node.name in {'allowed_file', 'predict_expenses', 'photo_url'}:
             code = '\n'.join(lines[node.lineno-1:node.end_lineno])
             funcs[node.name] = code
     ns = {}
@@ -26,9 +26,14 @@ def load_utils():
     class Expense:
         pass
     ns['Expense'] = Expense
+    def url_for(endpoint, filename=None):
+        if endpoint == 'static':
+            return f"/static/{filename}"
+        return f"/{endpoint}"
+    ns['url_for'] = url_for
     for code in funcs.values():
         exec(code, ns)
-    return ns['allowed_file'], ns['predict_expenses'], Expense
+    return ns['allowed_file'], ns['predict_expenses'], ns['photo_url'], Expense
 
 
 @pytest.fixture(scope='function')
@@ -46,13 +51,13 @@ class FakeQuery:
 
 
 def test_predict_expenses_returns_zero(utils):
-    allowed_file, predict_expenses, Expense = utils
+    allowed_file, predict_expenses, photo_url, Expense = utils
     Expense.query = FakeQuery([types.SimpleNamespace(amount=100)])
     assert predict_expenses(1) == 0
 
 
 def test_predict_expenses_multiple(utils):
-    allowed_file, predict_expenses, Expense = utils
+    allowed_file, predict_expenses, photo_url, Expense = utils
     amounts = [100, 150, 200]
     Expense.query = FakeQuery([types.SimpleNamespace(amount=a) for a in amounts])
     # avg increase = (200 - 100) / (3 - 1) = 50 -> predicted = 200 + 50 = 250
@@ -60,7 +65,18 @@ def test_predict_expenses_multiple(utils):
 
 
 def test_allowed_file(utils):
-    allowed_file, predict_expenses, Expense = utils
+    allowed_file, predict_expenses, photo_url, Expense = utils
     assert allowed_file('photo.png')
     assert allowed_file('picture.JPG')
     assert not allowed_file('document.pdf')
+
+
+def test_photo_url_http(utils):
+    _, _, photo_url, _ = utils
+    url = 'http://example.com/image.jpg'
+    assert photo_url(url) == url
+
+
+def test_photo_url_local(utils):
+    _, _, photo_url, _ = utils
+    assert photo_url('car.jpg') == '/static/car.jpg'


### PR DESCRIPTION
## Summary
- add `photo_url` filter in `Avtopark.py` and register it with Flask
- simplify template photo URL logic using the new filter
- extend unit tests to cover the filter behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685405e10bd08331ba8b7726afaca8d7