### PR TITLE
Fix whitespace in photo URLs

### DIFF
--- a/Avtopark.py
+++ b/Avtopark.py
@@ -223,6 +223,7 @@ def photo_url(photo_path):
     """Return a usable URL for a photo path."""
     if not photo_path:
         return photo_path
+    photo_path = photo_path.strip()
     if photo_path.startswith('http'):
         return photo_path
     return url_for('static', filename=photo_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,6 +99,13 @@ def test_photo_url_local(utils):
     assert photo_url('car.jpg') == '/static/car.jpg'
 
 
+def test_photo_url_strip(utils):
+    _, _, photo_url, _, _ = utils
+    assert photo_url('  car.jpg ') == '/static/car.jpg'
+    https_url = 'https://example.com/photo.jpg'
+    assert photo_url(f' {https_url} ') == https_url
+
+
 def test_upload_image_success(utils):
     _, _, _, upload_image, ns = utils
     uploaded = {}


### PR DESCRIPTION
## Summary
- trim whitespace in the `photo_url` filter so URLs stored with extra spaces don't break
- expand unit tests for the filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540ef40ce48331be4cf442bef8c33b