### PR TITLE
Handle empty photo_url inputs

### DIFF
--- a/Avtopark.py
+++ b/Avtopark.py
@@ -221,9 +221,11 @@ def upload_image(file):
 @app.template_filter('photo_url')
 def photo_url(photo_path):
     """Return a usable URL for a photo path."""
-    if not photo_path:
+    if photo_path is None:
         return photo_path
     photo_path = photo_path.strip()
+    if not photo_path:
+        return photo_path
     if photo_path.startswith('http'):
         return photo_path
     return url_for('static', filename=photo_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,6 +106,12 @@ def test_photo_url_strip(utils):
     assert photo_url(f' {https_url} ') == https_url
 
 
+def test_photo_url_empty_after_strip(utils):
+    """photo_url should return an empty string when only spaces are provided."""
+    _, _, photo_url, _, _ = utils
+    assert photo_url('  ') == ''
+
+
 def test_upload_image_success(utils):
     _, _, _, upload_image, ns = utils
     uploaded = {}


### PR DESCRIPTION
## Summary
- trim spaces before validating photo path
- return early if the trimmed photo path is empty
- check that `photo_url('  ')` returns an empty string

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685413a15518833194bb8ace50f2c1d9