### PR TITLE
Update README for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,24 @@ Install the project dependencies and run `pytest` from the repository root:
 pip install -r requirements.txt
 pytest
 ```
+
+## Configuration
+
+The application relies on a few secrets that should be provided through
+environment variables. **Do not commit a `.env` file containing these values.**
+
+Set the following variables before running the app or the tests:
+
+* `SECRET_KEY` – secret key used by Flask.
+* `CLOUDINARY_URL` – connection string for your Cloudinary account.
+
+Example on Linux or macOS:
+
+```bash
+export SECRET_KEY=your-secret
+export CLOUDINARY_URL=cloudinary://<api_key>:<api_secret>@<cloud_name>
+```
+
+You may place these lines in a local `.env` file for convenience, but keep in
+mind that `.env` is ignored by Git and should never be added to the
+repository.


### PR DESCRIPTION
## Summary
- document environment variables for secrets such as `CLOUDINARY_URL` and `SECRET_KEY`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541af3ac2c83319ce88e6ff0afb16e