### PR TITLE
Add utility to correct Upload paths

### DIFF
--- a/fix_upload_paths.py
+++ b/fix_upload_paths.py
@@ -1,0 +1,25 @@
+import sqlite3
+
+DB_PATH = "instance/fleet.db"
+
+conn = sqlite3.connect(DB_PATH)
+cursor = conn.cursor()
+
+cursor.execute(
+    """
+    UPDATE vehicle
+    SET photo = REPLACE(photo, 'Uploads/', 'uploads/')
+    WHERE photo LIKE 'Uploads/%'
+    """
+)
+
+cursor.execute(
+    """
+    UPDATE expense
+    SET receipt_photo = REPLACE(receipt_photo, 'Uploads/', 'uploads/')
+    WHERE receipt_photo LIKE 'Uploads/%'
+    """
+)
+
+conn.commit()
+conn.close()


### PR DESCRIPTION
## Summary
- add `fix_upload_paths.py` to rewrite `Uploads/` paths in `instance/fleet.db`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68541b5204108331ad86f3d463b3b546