### PR TITLE
Fix Cloudinary URL paths

### DIFF
--- a/fix_upload_paths.py
+++ b/fix_upload_paths.py
@@ -13,11 +13,28 @@ cursor.execute(
     """
 )
 
+# Remove accidental "static/" prefix before Cloudinary URLs
+cursor.execute(
+    """
+    UPDATE vehicle
+    SET photo = substr(photo, 8)
+    WHERE photo LIKE 'static/http%'
+    """
+)
+
 cursor.execute(
     """
     UPDATE expense
     SET receipt_photo = REPLACE(receipt_photo, 'Uploads/', 'uploads/')
     WHERE receipt_photo LIKE 'Uploads/%'
+    """
+)
+
+cursor.execute(
+    """
+    UPDATE expense
+    SET receipt_photo = substr(receipt_photo, 8)
+    WHERE receipt_photo LIKE 'static/http%'
     """
 )
 


### PR DESCRIPTION
## Summary
- update `fix_upload_paths.py` to remove erroneous `static/` prefix from stored Cloudinary URLs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854262ee8f88331b11d5804933ad732