### PR TITLE
Use DATABASE_URL env var for DB

### DIFF
--- a/Avtopark.py
+++ b/Avtopark.py
@@ -28,7 +28,10 @@ BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 app = Flask(__name__)
 
 app.config['SECRET_KEY'] = os.environ.get("SECRET_KEY", "fallback-key")
-app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{os.path.join(BASE_DIR, "instance", "fleet.db")}'
+app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get(
+    'DATABASE_URL',
+    f"sqlite:///{os.path.join(BASE_DIR, 'instance', 'fleet.db')}"
+)
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['UPLOAD_FOLDER'] = os.path.join(BASE_DIR, 'static', 'uploads')
 app.config['ALLOWED_EXTENSIONS'] = {'png', 'jpg', 'jpeg'}

--- a/README.md
+++ b/README.md
@@ -18,14 +18,23 @@ Set the following variables before running the app or the tests:
 
 * `SECRET_KEY` – secret key used by Flask.
 * `CLOUDINARY_URL` – connection string for your Cloudinary account.
+* `DATABASE_URL` – optional SQLAlchemy URI to use instead of the default
+  SQLite database.
 
 Example on Linux or macOS:
 
 ```bash
 export SECRET_KEY=your-secret
 export CLOUDINARY_URL=cloudinary://<api_key>:<api_secret>@<cloud_name>
+export DATABASE_URL=postgresql://user:pass@localhost:5432/fleet
 ```
 
 You may place these lines in a local `.env` file for convenience, but keep in
 mind that `.env` is ignored by Git and should never be added to the
 repository.
+
+After configuring the database, apply migrations with:
+
+```bash
+flask db upgrade
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ reportlab
 cloudinary
 python-dotenv
 pytest>=8.0.0
+psycopg2-binary


### PR DESCRIPTION
## Summary
- make SQLALCHEMY_DATABASE_URI use `DATABASE_URL` env var
- add `psycopg2-binary` dependency
- document `DATABASE_URL` and running migrations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685430800a548331862d98a64cca224b